### PR TITLE
added pagination to some of Miko's move, for visualization of red cape hitboxes

### DIFF
--- a/src/characters/doremy.json
+++ b/src/characters/doremy.json
@@ -1,7 +1,7 @@
 {
   "name": "doremy",
   "aliases": ["santa"],
-  "startingRow": 485,
+  "startingRow": 487,
   "colour": "#FF6CD9",
   "moves": [
     {

--- a/src/characters/joon.json
+++ b/src/characters/joon.json
@@ -1,7 +1,7 @@
 {
   "name": "joon",
   "aliases": ["jo'on", "jyoon", "june", "john", "rich"],
-  "startingRow": 580,
+  "startingRow": 582,
   "colour": "#00FF00",
   "moves": [
     {

--- a/src/characters/kasen.json
+++ b/src/characters/kasen.json
@@ -1,6 +1,6 @@
 {
   "name": "kasen",
-  "startingRow": 328,
+  "startingRow": 330,
   "colour": "#00FF00",
   "moves": [
     {

--- a/src/characters/koishi.json
+++ b/src/characters/koishi.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi",
   "aliases": ["koi"],
-  "startingRow": 227,
+  "startingRow": 229,
   "colour": "#00FF00",
   "moves": [
     {

--- a/src/characters/kokoro.json
+++ b/src/characters/kokoro.json
@@ -1,7 +1,7 @@
 {
   "name": "kokoro",
   "aliases": ["koko"],
-  "startingRow": 291,
+  "startingRow": 293,
   "colour": "#FFB2E4",
   "moves": [
     {

--- a/src/characters/mamizou.json
+++ b/src/characters/mamizou.json
@@ -1,7 +1,7 @@
 {
   "name": "mamizou",
   "aliases": ["mami"],
-  "startingRow": 257,
+  "startingRow": 259,
   "colour": "#00ff00",
   "moves": [
     {

--- a/src/characters/miko.json
+++ b/src/characters/miko.json
@@ -137,14 +137,24 @@
         {
           "title": "With red cape",
           "image": "Miko-red-66a.gif",
-          "rowOffset": 21
+          "rowOffset": 31
         }
       ]
     },
     {
       "names": ["db", "66b", "dashb"],
-      "image": "Miko66b.png",
-      "rowOffset": 22
+      "pages": [
+        {
+          "title": "No red cape",
+          "image": "Miko66b.png",
+          "rowOffset": 22
+        },
+        {
+          "title": "With red cape",
+          "image": "Miko66b.png",
+          "rowOffset": 32
+        }
+      ]
     },
     {
       "names": ["ab", "occult"],

--- a/src/characters/miko.json
+++ b/src/characters/miko.json
@@ -5,13 +5,33 @@
   "moves": [
     {
       "names": ["5a", "a", "4a", "c5a"],
-      "image": "Mikoc5a.gif",
-      "rowOffset": 0
+      "pages": [
+        {
+          "title": "No red cape",
+          "image": "Mikoc5a.gif",
+          "rowOffset": 0
+        },
+        {
+          "title": "With red cape",
+          "image": "Miko-red-4a.gif",
+          "rowOffset": 0
+        }
+      ]
     },
     {
       "names": ["f5a"],
-      "image": "miko-f5a-no-cape.gif",
-      "rowOffset": 1
+      "pages": [
+        {
+          "title": "No red cape",
+          "image": "miko-f5a-no-cape.gif",
+          "rowOffset": 1
+        },
+        {
+          "title": "With red cape",
+          "image": "Miko-red-f5a.gif",
+          "rowOffset": 1
+        }
+      ]
     },
     {
       "names": ["6a"],
@@ -30,8 +50,18 @@
     },
     {
       "names": ["ja", "j5a"],
-      "image": "Miko-j5a.gif",
-      "rowOffset": 5
+      "pages": [
+        {
+          "title": "No red cape",
+          "image": "Miko-j5a.gif",
+          "rowOffset": 5
+        },
+        {
+          "title": "With red cape",
+          "image": "Miko-red-j5a.gif",
+          "rowOffset": 5
+        }
+      ]
     },
     {
       "names": ["j6a"],
@@ -98,8 +128,18 @@
     },
     {
       "names": ["da", "66a", "dasha"],
-      "image": "Miko66a.gif",
-      "rowOffset": 21
+      "pages": [
+        {
+          "title": "No red cape",
+          "image": "Miko66a.gif",
+          "rowOffset": 21
+        },
+        {
+          "title": "With red cape",
+          "image": "Miko-red-66a.gif",
+          "rowOffset": 21
+        }
+      ]
     },
     {
       "names": ["db", "66b", "dashb"],

--- a/src/characters/mokou.json
+++ b/src/characters/mokou.json
@@ -1,6 +1,6 @@
 {
   "name": "mokou",
-  "startingRow": 361,
+  "startingRow": 363,
   "colour": "#FF0000",
   "moves": [
     {

--- a/src/characters/nitori.json
+++ b/src/characters/nitori.json
@@ -1,6 +1,6 @@
 {
   "name": "nitori",
-  "startingRow": 194,
+  "startingRow": 196,
   "colour": "#007aff",
   "moves": [
     {

--- a/src/characters/reisen.json
+++ b/src/characters/reisen.json
@@ -1,7 +1,7 @@
 {
   "name": "reisen",
   "aliases": ["udonge"],
-  "startingRow": 455,
+  "startingRow": 457,
   "colour": "#E36CFF",
   "moves": [
     {

--- a/src/characters/sukuna.json
+++ b/src/characters/sukuna.json
@@ -1,7 +1,7 @@
 {
   "name": "sukuna",
   "aliases": ["shinmyoumaru", "shimmy", "sinmyoumaru"],
-  "startingRow": 391,
+  "startingRow": 393,
   "colour": "#FF00A6",
   "moves": [
     {

--- a/src/characters/sumireko.json
+++ b/src/characters/sumireko.json
@@ -1,7 +1,7 @@
 {
   "name": "sumireko",
   "aliases": ["sumi", "usami", "susami"],
-  "startingRow": 422,
+  "startingRow": 424,
   "colour": "#FF0000",
   "moves": [
     {

--- a/src/characters/tenshi.json
+++ b/src/characters/tenshi.json
@@ -1,7 +1,7 @@
 {
   "name": "tenshi",
   "aliases": ["tenko"],
-  "startingRow": 515,
+  "startingRow": 517,
   "colour": "#0000FF",
   "moves": [
     {

--- a/src/characters/yukari.json
+++ b/src/characters/yukari.json
@@ -1,7 +1,7 @@
 {
   "name": "yukari",
   "aliases": ["bestthcharacterdont@me"],
-  "startingRow": 545,
+  "startingRow": 547,
   "colour": "#FFD400",
   "moves": [
     {


### PR DESCRIPTION
### Summary
Makes some of Miko's moves paginated like spellcards.

### Purpose of change
To allow users to see the different hitboxes between her with and without red cape.

### Describe the solution
The gifs were already uploaded, so all that was needed was to make the avaiable to the users.

### Describe alternatives you've considered
Adding copies to the moves with the same "rowOffset" but with a different "image" value pointing to the red cape gifs. E.g.: "!miko redj5a".

### Testing
A complete sucess
![Screenshot at 2023-10-31 11-40-41](https://github.com/JustAPenguin9/Akyuu-bot/assets/16021747/bf3cc201-1e05-4f27-bc47-c5b159cf2292)
![Screenshot at 2023-10-31 11-40-28](https://github.com/JustAPenguin9/Akyuu-bot/assets/16021747/a5c04e16-0057-4bbc-b6fd-e1ed625687b8)


### Additional context
As discussed. it will be best to use this pagination to place her 66a and 66b on different rows, as they change framedata and damage with red cape.
Her normal 66a needs a remake, and 66b still has no gif version. I will try to extract them another day.
