### PR TITLE
link Kokoro 6c gif to the move

### DIFF
--- a/src/characters/kokoro.json
+++ b/src/characters/kokoro.json
@@ -123,6 +123,7 @@
     },
     {
       "names": ["6c"],
+      "image": "Kokoro-6c.gif",
       "rowOffset": 23
     },
     {


### PR DESCRIPTION
### Summary
Link Kokoro's 6c to the move

### Purpose of change
Link Kokoro's 6c to the move

### Describe the solution
Kokoro's 6c already existed https://github.com/JustAPenguin9/Akyuu-bot/blob/master/attachments/kokoro/Kokoro-6c.gif
but was not linked to it's move. This PR simply adds the image line to kokoro's json.

### Describe alternatives you've considered
None.

### Testing
None.

### Additional context
@SonofGod1998 had already done this gif a few years ago, but it was not linked to the move. https://discord.com/channels/273513597622157322/273732273747263488/882067949018562670