### PR TITLE
Add attachments from wiki to characters missing them

### DIFF
--- a/character-sql/ichirin.sql
+++ b/character-sql/ichirin.sql
@@ -62,10 +62,10 @@ INSERT INTO `moves` (
 			"title": "j5a",
 			"startup": "11f",
 			"active": "3f",
-			"recovery": "35f",
+			"recovery": "29f",
 			"damage": "562 or 500",
 			"stun": 0,
-			"attachment": "https://wiki.koumakan.jp/images/aocf/8/81/Ichirinj5a.png"
+			"attachment": "https://wiki.koumakan.jp/images/aocf/7/7d/IchirinUnzanj5a.gif"
 		}
 	]}')),
 	(@game, @character, 'j6a', JSON_COMPACT('{ "variations": [

--- a/character-sql/joon.sql
+++ b/character-sql/joon.sql
@@ -198,7 +198,7 @@ INSERT INTO `moves` (
 			"recovery": 27,
 			"damage": 500,
 			"stun": 0,
-			"attachment": "https://wiki.koumakan.jp/images/aocf/3/37/Joon66a.png"
+			"attachment": "https://wiki.koumakan.jp/images/aocf/0/0f/Joon66a.gif"
 		}
 	]}')),
 	(@game, @character, 'db,dashb,66b', JSON_COMPACT('{ "variations": [

--- a/character-sql/kasen.sql
+++ b/character-sql/kasen.sql
@@ -152,7 +152,8 @@ INSERT INTO `moves` (
 			"title": "5c",
 			"startup": 26,
 			"damage": "1381 (500 + 1000)",
-			"stun": "40 (on ball)"
+			"stun": "40 (on ball)",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/9/9a/5c.gif"
 		}
 	]}')),
 	(@game, @character, '6c', JSON_COMPACT('{ "variations": [

--- a/character-sql/reisen.sql
+++ b/character-sql/reisen.sql
@@ -11,7 +11,8 @@ INSERT INTO `moves` (
 			"active": 2,
 			"recovery": 12,
 			"damage": 200,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/1/1c/Reisenc5a.gif"			
 		},
 		{
 			"title": "far 5a",
@@ -19,7 +20,8 @@ INSERT INTO `moves` (
 			"active": 3,
 			"recovery": 17,
 			"damage": 500,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/f/fa/Reisen-f5a.gif"
 		}
 	]}')),
 	(@game, @character, '6a', JSON_COMPACT('{ "variations": [
@@ -29,7 +31,8 @@ INSERT INTO `moves` (
 			"active": 2,
 			"recovery": 27,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/4/43/Reisen6a.png"
 		}
 	]}')),
 	(@game, @character, '8a', JSON_COMPACT('{ "variations": [
@@ -39,7 +42,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 43,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/0/0e/Reisen-8a.gif"
 		}
 	]}')),
 	(@game, @character, '2a', JSON_COMPACT('{ "variations": [
@@ -49,7 +53,8 @@ INSERT INTO `moves` (
 			"active": 10,
 			"recovery": 18,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/1/16/Reisen2a.png"
 		}
 	]}')),
 	(@game, @character, 'ja,j5a', JSON_COMPACT('{ "variations": [
@@ -59,7 +64,8 @@ INSERT INTO `moves` (
 			"active": 8,
 			"recovery": 40,
 			"damage": 500,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/a/aa/Reisenj5a.png"
 		}
 	]}')),
 	(@game, @character, 'j6a', JSON_COMPACT('{ "variations": [
@@ -69,7 +75,8 @@ INSERT INTO `moves` (
 			"active": "2f > 4f not active > 2f > 4f not active > 2f",
 			"recovery": 24,
 			"damage": "919 (if all hit)",
-			"stun": "20 + 10 x 2 = [40]"
+			"stun": "20 + 10 x 2 = [40]",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/e/e6/Reisen-j6a.gif"
 		}
 	]}')),
 	(@game, @character, 'j8a', JSON_COMPACT('{ "variations": [
@@ -79,7 +86,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 24,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/c/cd/Reisen8a.png"
 		},
 		{
 			"title": "bottom lane j8a",
@@ -87,7 +95,8 @@ INSERT INTO `moves` (
 			"active": 86,
 			"recovery": 41,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/c/cd/Reisen8a.png"
 		}
 	]}')),
 	(@game, @character, 'j2a', JSON_COMPACT('{ "variations": [
@@ -97,7 +106,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 43,
 			"damage": "919 (if all hit)",
-			"stun": "20 + 10 x 2 = [40]"
+			"stun": "20 + 10 x 2 = [40]",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/a/a8/Reisenj2a.png"
 		}
 	]}')),
 	(@game, @character, '5b,b', JSON_COMPACT('{ "variations": [
@@ -173,7 +183,8 @@ INSERT INTO `moves` (
 			"active": 25,
 			"recovery": 20,
 			"damage": "1240 (if all hit)",
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/8/83/Reisen-2c.gif"
 		}
 	]}')),
 	(@game, @character, '8c', JSON_COMPACT('{ "variations": [
@@ -190,7 +201,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 16,
 			"damage": 675,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/4/49/Reisen-66a.gif"
 		}
 	]}')),
 	(@game, @character, 'db,dashb,66b', JSON_COMPACT('{ "variations": [
@@ -200,7 +212,8 @@ INSERT INTO `moves` (
 			"active": "2f > 4f not active > 2f > 4f not active > 2f",
 			"recovery": 29,
 			"damage": "1020 (if all hit)",
-			"stun": "10 x 3 = [30]"
+			"stun": "10 x 3 = [30]",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/c/cd/Reisen-66b.gif"
 		}
 	]}')),
 	(@game, @character, 'ab,occult', JSON_COMPACT('{ "variations": [

--- a/character-sql/sukuna.sql
+++ b/character-sql/sukuna.sql
@@ -11,7 +11,8 @@ INSERT INTO `moves` (
 			"active": 2,
 			"recovery": 11,
 			"damage": 180,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/7/70/Sukunac5a.gif"
 		},
 		{
 			"title": "far 5a",
@@ -19,7 +20,8 @@ INSERT INTO `moves` (
 			"active": 4,
 			"recovery": 17,
 			"damage": 470,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/1/15/Shinmy-f5a.gif"
 		}
 	]}')),
 	(@game, @character, '6a', JSON_COMPACT('{ "variations": [
@@ -29,7 +31,8 @@ INSERT INTO `moves` (
 			"active": 8,
 			"recovery": 20,
 			"damage": 690,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/3/37/Sukuna6a.png"
 		}
 	]}')),
 	(@game, @character, '8a', JSON_COMPACT('{ "variations": [
@@ -39,7 +42,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 78,
 			"damage": 690,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/7/70/Sukuna8a.png"
 		}
 	]}')),
 	(@game, @character, '2a', JSON_COMPACT('{ "variations": [
@@ -49,7 +53,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 26,
 			"damage": 625,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/5/53/Sukuna2a.png"
 		}
 	]}')),
 	(@game, @character, 'ja,j5a', JSON_COMPACT('{ "variations": [
@@ -59,7 +64,8 @@ INSERT INTO `moves` (
 			"active": 8,
 			"recovery": 28,
 			"damage": 470,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/c/c9/Sukunaj5a.png"
 		}
 	]}')),
 	(@game, @character, 'j6a', JSON_COMPACT('{ "variations": [
@@ -69,7 +75,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 35,
 			"damage": 690,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/2/25/Sukunaj6a.png"
 		}
 	]}')),
 	(@game, @character, 'j8a', JSON_COMPACT('{ "variations": [
@@ -79,7 +86,8 @@ INSERT INTO `moves` (
 			"active": 8,
 			"recovery": 30,
 			"damage": 690,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/6/64/Sukuna-j8a.gif"
 		}
 	]}')),
 	(@game, @character, 'j2a', JSON_COMPACT('{ "variations": [
@@ -89,7 +97,8 @@ INSERT INTO `moves` (
 			"active": 7,
 			"recovery": 42,
 			"damage": 625,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/4/41/Sukuna-j2a.gif"
 		}
 	]}')),
 	(@game, @character, '5b,b', JSON_COMPACT('{ "variations": [
@@ -120,7 +129,8 @@ INSERT INTO `moves` (
 			"active": "2f > 5f not active > 2f > 5f not active > 2f > 5f not active > 2f > 5f not active > 2f",
 			"recovery": 35,
 			"damage": "511 (if all hit)",
-			"stun": "25 (5 per)"
+			"stun": "25 (5 per)",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/3/3c/Shinmy-6b.gif"
 		}
 	]}')),
 	(@game, @character, 'cb,chargeb,[b]', JSON_COMPACT('{ "variations": [
@@ -159,7 +169,8 @@ INSERT INTO `moves` (
 			"active": "min: 4f, mean: 12f, max: reaching mid lane",
 			"recovery": 26,
 			"damage": "845 (if all hit, 250 per)",
-			"stun": "40 (on last hit)"
+			"stun": "40 (on last hit)",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/0/0b/Shinmy-j6c-one-loop.gif"
 		}
 	]}')),
 	(@game, @character, '4c', JSON_COMPACT('{ "variations": [
@@ -183,7 +194,8 @@ INSERT INTO `moves` (
 			"active": "39f-55f or until land canceled",
 			"recovery": 15,
 			"damage": "955 (if all hit)",
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/7/7c/Shinmy-8c.gif"
 		},
 		{
 			"title": "8c bottom lane",
@@ -191,7 +203,8 @@ INSERT INTO `moves` (
 			"active": "39f-55f or until land canceled",
 			"recovery": 15,
 			"damage": "955 (if all hit)",
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/7/7c/Shinmy-8c.gif"
 		}
 	]}')),
 	(@game, @character, 'da,dasha,66a', JSON_COMPACT('{ "variations": [
@@ -201,7 +214,8 @@ INSERT INTO `moves` (
 			"active": 4,
 			"recovery": 17,
 			"damage": 500,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/4/43/Sukuna66a.png"
 		}
 	]}')),
 	(@game, @character, 'db,dashb,66b', JSON_COMPACT('{ "variations": [
@@ -211,7 +225,8 @@ INSERT INTO `moves` (
 			"active": 26,
 			"recovery": 28,
 			"damage": "1496 (if all hit)",
-			"stun": "40 (if all hit)"
+			"stun": "40 (if all hit)",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/3/39/Sukuna66b.png"
 		}
 	]}')),
 	(@game, @character, 'ab,occult', JSON_COMPACT('{ "variations": [

--- a/character-sql/sumi.sql
+++ b/character-sql/sumi.sql
@@ -11,7 +11,8 @@ INSERT INTO `moves` (
 			"active": "2f > 3f not active > 2f",
 			"recovery": 12,
 			"damage": 200,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/5/54/Sumic5a.gif"
 		},
 		{
 			"title": "far 5a",
@@ -19,7 +20,8 @@ INSERT INTO `moves` (
 			"active": 7,
 			"recovery": 18,
 			"damage": 500,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/e/ee/Usamif5a.png"
 		}
 	]}')),
 	(@game, @character, '6a', JSON_COMPACT('{ "variations": [
@@ -29,7 +31,8 @@ INSERT INTO `moves` (
 			"active": 3,
 			"recovery": 28,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/2/23/Usami6a.png"
 		}
 	]}')),
 	(@game, @character, '8a', JSON_COMPACT('{ "variations": [
@@ -39,7 +42,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 24,
 			"damage": "1039 (if all hit)",
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/c/ca/Usami8a.png"
 		}
 	]}')),
 	(@game, @character, '2a', JSON_COMPACT('{ "variations": [
@@ -49,7 +53,8 @@ INSERT INTO `moves` (
 			"active": 5,
 			"recovery": 24,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/6/6e/Usami2a.png"
 		}
 	]}')),
 	(@game, @character, 'ja,j5a', JSON_COMPACT('{ "variations": [
@@ -59,7 +64,8 @@ INSERT INTO `moves` (
 			"active": 13,
 			"recovery": 27,
 			"damage": 500,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/2/21/Usamij5a.png"
 		}
 	]}')),
 	(@game, @character, 'j6a', JSON_COMPACT('{ "variations": [
@@ -69,7 +75,8 @@ INSERT INTO `moves` (
 			"active": 3,
 			"recovery": 24,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/9/92/Usamij6a.png"
 		}
 	]}')),
 	(@game, @character, 'j8a', JSON_COMPACT('{ "variations": [
@@ -79,7 +86,8 @@ INSERT INTO `moves` (
 			"active": 5,
 			"recovery": 26,
 			"damage": "1039 (if all hit)",
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/5/55/Usamij8a.png"
 		}
 	]}')),
 	(@game, @character, 'j2a', JSON_COMPACT('{ "variations": [
@@ -89,7 +97,8 @@ INSERT INTO `moves` (
 			"active": 5,
 			"recovery": 24,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/0/00/Usamij2a.png"
 		}
 	]}')),
 	(@game, @character, '5b,b', JSON_COMPACT('{ "variations": [
@@ -181,7 +190,8 @@ INSERT INTO `moves` (
 			"active": 35,
 			"recovery": 22,
 			"damage": 675,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/4/42/Usami66a.png"
 		}
 	]}')),
 	(@game, @character, 'db,dashb,66b', JSON_COMPACT('{ "variations": [
@@ -191,7 +201,8 @@ INSERT INTO `moves` (
 			"active": 2,
 			"recovery": 35,
 			"damage": 825,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/a/a3/Usami66b.png"
 		}
 	]}')),
 	(@game, @character, 'ab,occult', JSON_COMPACT('{ "variations": [

--- a/character-sql/tenshi.sql
+++ b/character-sql/tenshi.sql
@@ -11,7 +11,8 @@ INSERT INTO `moves` (
 			"active": 2,
 			"recovery": 12,
 			"damage": 200,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/a/a7/Tenshic5a.gif"
 		},
 		{
 			"title": "far 5a",
@@ -19,7 +20,8 @@ INSERT INTO `moves` (
 			"active": 3,
 			"recovery": 22,
 			"damage": 500,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/7/7b/Tenshif5a.png"
 		}
 	]}')),
 	(@game, @character, '6a', JSON_COMPACT('{ "variations": [
@@ -29,7 +31,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 23,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/5/5f/Tenshi6a.png"
 		}
 	]}')),
 	(@game, @character, '8a', JSON_COMPACT('{ "variations": [
@@ -39,7 +42,8 @@ INSERT INTO `moves` (
 			"active": 3,
 			"recovery": 21,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/1/1b/Tenshi8a.png"
 		}
 	]}')),
 	(@game, @character, '2a', JSON_COMPACT('{ "variations": [
@@ -49,7 +53,8 @@ INSERT INTO `moves` (
 			"active": 4,
 			"recovery": 21,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/a/a8/Tenshi2a.png"
 		}
 	]}')),
 	(@game, @character, 'ja,j5a', JSON_COMPACT('{ "variations": [
@@ -59,7 +64,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 35,
 			"damage": 500,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/6/6b/Tenshij5a.png"
 		}
 	]}')),
 	(@game, @character, 'j6a', JSON_COMPACT('{ "variations": [
@@ -69,7 +75,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 34,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/e/eb/Tenshij6a.png"
 		}
 	]}')),
 	(@game, @character, 'j8a', JSON_COMPACT('{ "variations": [
@@ -79,7 +86,8 @@ INSERT INTO `moves` (
 			"active": 3,
 			"recovery": 33,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/b/b7/Tenshij8a.png"
 		}
 	]}')),
 	(@game, @character, 'j2a', JSON_COMPACT('{ "variations": [
@@ -89,7 +97,8 @@ INSERT INTO `moves` (
 			"active": 10,
 			"recovery": 38,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/2/23/Tenshij2a.png"
 		}
 	]}')),
 	(@game, @character, '5b,b', JSON_COMPACT('{ "variations": [
@@ -123,7 +132,8 @@ INSERT INTO `moves` (
 			"startup": 11,
 			"recovery": "35f, catch: 25f",
 			"damage": "479 (if all hit)",
-			"stun": 30
+			"stun": "10 x 3 = [30]",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/b/b5/Tenshi-6b.gif"
 		}
 	]}')),
 	(@game, @character, 'cb,chargeb,[b]', JSON_COMPACT('{ "variations": [
@@ -162,7 +172,8 @@ INSERT INTO `moves` (
 			"active": 15,
 			"recovery": 35,
 			"damage": 1429,
-			"stun": "40 (on second hit)"
+			"stun": "40 (on second hit)",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/4/48/Tenshi-4c.gif"
 		}
 	]}')),
 	(@game, @character, '2c', JSON_COMPACT('{ "variations": [
@@ -172,7 +183,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 36,
 			"damage": 1000,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/d/d4/Tenshi2c.gif"
 		}
 	]}')),
 	(@game, @character, '8c', JSON_COMPACT('{ "variations": [
@@ -189,7 +201,8 @@ INSERT INTO `moves` (
 			"active": 14,
 			"recovery": 15,
 			"damage": 585,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/2/2d/Tenshi66a.png"
 		}
 	]}')),
 	(@game, @character, 'db,dashb,66b', JSON_COMPACT('{ "variations": [
@@ -199,7 +212,8 @@ INSERT INTO `moves` (
 			"active": 18,
 			"recovery": 17,
 			"damage": 1170,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/b/b6/Tenshi66b.png"
 		}
 	]}')),
 	(@game, @character, 'ab,occult', JSON_COMPACT('{ "variations": [
@@ -248,6 +262,7 @@ INSERT INTO `moves` (
 			"active": 41,
 			"recovery": 39,
 			"damage": 4925,
-			"stun": 100
+			"stun": 100,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/7/74/Tenshi-LW.png"
 		}
 	]}'));

--- a/character-sql/yukari.sql
+++ b/character-sql/yukari.sql
@@ -11,7 +11,8 @@ INSERT INTO `moves` (
 			"active": 4,
 			"recovery": 22,
 			"damage": 200,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/2/2d/Yukaric5a.gif"
 		},
 		{
 			"title": "far 5a",
@@ -19,7 +20,8 @@ INSERT INTO `moves` (
 			"active": 5,
 			"recovery": 19,
 			"damage": 500,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/5/58/Yukari-f5a.gif"
 		}
 	]}')),
 	(@game, @character, '6a', JSON_COMPACT('{ "variations": [
@@ -29,7 +31,8 @@ INSERT INTO `moves` (
 			"active": 7,
 			"recovery": 30,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/4/43/Yukari6a.png"
 		}
 	]}')),
 	(@game, @character, '8a', JSON_COMPACT('{ "variations": [
@@ -39,7 +42,8 @@ INSERT INTO `moves` (
 			"active": "1st: 3f > 4f not active > 2nd: 6f",
 			"recovery": 24,
 			"damage": "1161 (750 second hit only)",
-			"stun": "40 (on last hit)"
+			"stun": "40 (on last hit)",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/8/84/Yukari-8a.gif"
 		}
 	]}')),
 	(@game, @character, '2a', JSON_COMPACT('{ "variations": [
@@ -49,7 +53,8 @@ INSERT INTO `moves` (
 			"active": 6,
 			"recovery": 20,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/a/a0/Yukari2a.png"
 		}
 	]}')),
 	(@game, @character, 'ja,j5a', JSON_COMPACT('{ "variations": [
@@ -59,7 +64,8 @@ INSERT INTO `moves` (
 			"active": 34,
 			"recovery": 38,
 			"damage": 515,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/e/e4/Yukari-j5a.gif"
 		}
 	]}')),
 	(@game, @character, 'j6a', JSON_COMPACT('{ "variations": [
@@ -69,7 +75,8 @@ INSERT INTO `moves` (
 			"active": 8,
 			"recovery": 36,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/2/21/Yukari-j6a.gif"
 		}
 	]}')),
 	(@game, @character, 'j8a', JSON_COMPACT('{ "variations": [
@@ -79,7 +86,8 @@ INSERT INTO `moves` (
 			"active": 26,
 			"recovery": 15,
 			"damage": 673,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/8/8e/Yukari-j8a.gif"
 		}
 	]}')),
 	(@game, @character, 'j2a', JSON_COMPACT('{ "variations": [
@@ -89,14 +97,16 @@ INSERT INTO `moves` (
 			"active": 7,
 			"recovery": 41,
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/5/52/Yukari-j2a.gif"
 		}
 	]}')),
 	(@game, @character, '5b,b', JSON_COMPACT('{ "variations": [
 		{
 			"title": "5b",
 			"damage": "478 (if all hit)",
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/6/6e/Projectile5b.png"
 		}
 	]}')),
 	(@game, @character, '2b', JSON_COMPACT('{ "variations": [
@@ -178,7 +188,8 @@ INSERT INTO `moves` (
 			"active": 2,
 			"recovery": 58,
 			"damage": 1000,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/0/09/Yukari-8c.gif"
 		}
 	]}')),
 	(@game, @character, 'da,dasha,66a', JSON_COMPACT('{ "variations": [
@@ -188,7 +199,8 @@ INSERT INTO `moves` (
 			"active": 24,
 			"recovery": 20,
 			"damage": 947,
-			"stun": 0
+			"stun": 0,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/9/90/Yukari66a.png"
 		}
 	]}')),
 	(@game, @character, 'db,dashb,66b', JSON_COMPACT('{ "variations": [
@@ -198,7 +210,8 @@ INSERT INTO `moves` (
 			"active": "3f > 6f not active > 3f > 6f not active > 3f > 6f not active > 3f > 6f not active > 3f",
 			"recovery": 38,
 			"damage": 1193,
-			"stun": "40 (on last hit)"
+			"stun": "40 (on last hit)",
+			"attachment": "https://wiki.koumakan.jp/images/aocf/7/7d/Yukari66b.png"
 		}
 	]}')),
 	(@game, @character, 'ab,occult', JSON_COMPACT('{ "variations": [


### PR DESCRIPTION
### Summary
Add attachments from wiki files 

### Purpose of change
Add links to attachments from wiki files to the bot: Ichirin, Joon, Kasen, Reisen, Shinmy, Sumireko, Tenshi and Yukari.

### Describe the solution
Went through all character pages and sql files to check for differences. Miko was left out because red cape would be too much trouble for now.

### Describe alternatives you've considered
Adding this funny frame of Shinmyoumaru with stretched feet.
![atkHighFront0004](https://github.com/user-attachments/assets/2071e8c0-82a5-47b2-bad2-62bc142082c0)

### Testing
None yet.

### Additional context
I can do Miko + red cape later, but not today. Also Lumina extracted Yukari's LW but the hitbox is a bit weird so i didn't upload it yet.