### PR TITLE
fix attachment on Miko j2a

### DIFF
--- a/character-sql/miko.sql
+++ b/character-sql/miko.sql
@@ -140,7 +140,7 @@ INSERT INTO `moves` (
 			"recovery": "42f",
 			"damage": "750",
 			"stun": 40,
-			"attachment": "https://wiki.koumakan.jp/images/aocf/d/d1/Mikoj6a-red.gif"
+			"attachment": "https://wiki.koumakan.jp/images/aocf/f/f1/Miko2a.png"
 		}
 	]}')),
 	(@game, @character, '5b,b', JSON_COMPACT('{ "variations": [

--- a/character-sql/miko.sql
+++ b/character-sql/miko.sql
@@ -79,7 +79,8 @@ INSERT INTO `moves` (
 			"active": "3f",
 			"recovery": "25f",
 			"damage": 750,
-			"stun": 40
+			"stun": 40,
+			"attachment": "https://wiki.koumakan.jp/images/aocf/f/f1/Miko2a.png"
 		}
 	]}')),
 	(@game, @character, 'ja,j5a', JSON_COMPACT('{ "variations": [
@@ -140,7 +141,7 @@ INSERT INTO `moves` (
 			"recovery": "42f",
 			"damage": "750",
 			"stun": 40,
-			"attachment": "https://wiki.koumakan.jp/images/aocf/f/f1/Miko2a.png"
+			"attachment": "https://wiki.koumakan.jp/images/aocf/e/e2/Miko-j2a-nocape.gif"
 		}
 	]}')),
 	(@game, @character, '5b,b', JSON_COMPACT('{ "variations": [


### PR DESCRIPTION
### Summary
Fix Miko's j2a which had an attachment link for j6a.

### Purpose of change
Fix Miko's j2a attachment link which was sent wrong in #108 

### Describe the solution
Changed the link from j6a to j2a.

### Describe alternatives you've considered
Adding J2a gif, which has hitboxes extracted https://wiki.koumakan.jp/images/aocf/e/e2/Miko-j2a-nocape.gif

### Testing
None yet.

### Additional context
2a has no hitboxes yet